### PR TITLE
Add support for latest version of Photino.Blazor

### DIFF
--- a/Photino.Blazor.CustomWindow.Sample/Photino.Blazor.CustomWindow.Sample.csproj
+++ b/Photino.Blazor.CustomWindow.Sample/Photino.Blazor.CustomWindow.Sample.csproj
@@ -2,14 +2,14 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ApplicationIcon>favicon.ico</ApplicationIcon>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
-        <PackageReference Include="Photino.Blazor" Version="2.7.0" />
-        <PackageReference Include="Photino.Native" Version="2.6.0" />
+        <PackageReference Include="Photino.Blazor" Version="3.0.11" />
+        <PackageReference Include="Photino.Native" Version="3.0.20" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Photino.Blazor.CustomWindow/Components/CustomWindow.razor.cs
+++ b/Photino.Blazor.CustomWindow/Components/CustomWindow.razor.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using Photino.Blazor.CustomWindow.Services;
-using PhotinoNET;
+using Photino.NET;
 using System.Drawing;
 namespace Photino.Blazor.CustomWindow.Components;
 

--- a/Photino.Blazor.CustomWindow/Photino.Blazor.CustomWindow.csproj
+++ b/Photino.Blazor.CustomWindow/Photino.Blazor.CustomWindow.csproj
@@ -27,7 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Photino.Blazor" Version="2.7.0" />
+      <PackageReference Include="Photino.Blazor" Version="3.0.11" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The namespacing for Photino changed in 3.0.x which makes Photino.Blazor.CustomWindow not usable in newer projects. This change updates the packages referenced and updates the used namespace.